### PR TITLE
Update ultimate_ga.php

### DIFF
--- a/ultimate_ga.php
+++ b/ultimate_ga.php
@@ -521,7 +521,7 @@ function uga_options() {
 function uga_track_user() {
   global $user_level;
   uga_debug('Start uga_track_user');
-  if (!user_level) {
+  if (!$user_level) {
     // user nog logged on -> track
     uga_debug('User not logged on');
     $result = true;


### PR DESCRIPTION
Fixed bug where $user_level -variable setting is not actually checked and you get an Notice message
    ( ! ) Notice: Use of undefined constant user_level - assumed 'user_level' in plugins/ultimate-google-analytics/ultimate_ga.php on line 524